### PR TITLE
replace webgl renderer with DOM+CSS3

### DIFF
--- a/ezmreader.js
+++ b/ezmreader.js
@@ -138,19 +138,13 @@ function animate(){
 
 
 // Keyboard input
-document.addEventListener('keyup', keyInput);
-
-function keyInput(key){
-
-    if (key.keyCode === 65 || key.keyCode === 37){
+document.addEventListener('keyup', function onKeyUp(key){
+    if (key.key === 'ArrowLeft' || key.key === 'a'){
         flipLeft();
-    }
-    if (key.keyCode === 68 || key.keyCode === 39){
+    } else if (key.key === 'ArrowRight' || key.key === 'd'){
         flipRight();
     }
-    
-}
-
+});
 
 // Mouse input
 document.addEventListener("pointerup", function onPointerUp(event){

--- a/ezmreader.js
+++ b/ezmreader.js
@@ -65,7 +65,8 @@ MANAGER.onLoad = function () {
 
 // Select template
 switch(TEMPLATE){
-    case 1: 
+    default:
+    case 1:
         card_size.set(421, 595);
         card_amount = 4; 
         textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/BACK.png'];
@@ -88,11 +89,6 @@ switch(TEMPLATE){
         textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/6.png', 'pages/7.png', 
         'pages/8.png', 'pages/9.png', 'pages/10.png', 'pages/11.png', 'pages/12.png', 'pages/13.png', 'pages/BACK.png'];
         break;
-    default:
-        card_size.set(421, 595);
-        card_amount = 4;
-        textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/BACK.png'];
-
 }
 
 

--- a/ezmreader.js
+++ b/ezmreader.js
@@ -34,7 +34,6 @@ const LOADER = new THREE.TextureLoader(MANAGER);
 const LOADING_OVERLAY = document.querySelector('#loading');
 let card_size = new THREE.Vector2();
 let card_amount;
-let mouse = new THREE.Vector2;
 let current_state = 0;
 let textures = [];
 let cards = [];
@@ -132,22 +131,6 @@ for (let a=0; a < card_amount; a++){
     scene.add(card);
 }
 
-
-// Create hitboxes for mouse control
-let hitbox_geo = new THREE.PlaneGeometry(card_size.x/2, card_size.y);
-let hitbox_mat = new THREE.MeshBasicMaterial({color: 0xf8f800});
-hitbox_mat.transparent = true;
-hitbox_mat.opacity = 0;
-let hitbox_right_mesh = new THREE.Mesh(hitbox_geo, hitbox_mat);
-hitbox_right_mesh.position.x = (card_size.x / 4) * 3;
-hitbox_right_mesh.position.z = 1;
-let hitbox_left_mesh = new THREE.Mesh(hitbox_geo, hitbox_mat);
-hitbox_left_mesh.position.x = -(card_size.x / 4) * 3;
-hitbox_left_mesh.position.z = 1;
-
-scene.add(hitbox_right_mesh);
-scene.add(hitbox_left_mesh);
-
 function animate(){
     requestAnimationFrame(animate);
     renderer.render(scene, camera);
@@ -170,27 +153,14 @@ function keyInput(key){
 
 
 // Mouse input
-let raycaster = new THREE.Raycaster();
-document.addEventListener("mouseup", raycast, false);
-
-function raycast(event){
-    
-    mouse.x = (event.clientX / window.innerWidth ) * 2 - 1;
-    mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
-    raycaster.setFromCamera(mouse, camera);
-    let intersects = raycaster.intersectObjects( scene.children );
-
-	for ( let i = 0; i < intersects.length; i++ ){
-        let intersected = intersects[0].object;
-
-        if (intersected == hitbox_left_mesh){
-            flipRight();
-        } else if (intersected == hitbox_right_mesh){
-            flipLeft();
-        }
+document.addEventListener("pointerup", function onPointerUp(event){
+    if (event.button !== 0) return;
+    if (event.clientX < window.innerWidth / 2) {
+        flipRight();
+    } else {
+        flipLeft();
     }
-}
-
+});
 
 // Flip page left
 function flipLeft(){

--- a/ezmreader.js
+++ b/ezmreader.js
@@ -62,6 +62,9 @@ MANAGER.onLoad = function () {
     LOADING_OVERLAY.remove();
 }
 
+function getTextures(num) {
+    return ['pages/FRONT.png', 'pages/INNERFRONT.png'].concat(new Array(num).fill().map((_, idx) => 'pages/' + (idx + 1) + '.png'), ['pages/BACK.png']);
+}
 
 // Select template
 switch(TEMPLATE){
@@ -69,25 +72,22 @@ switch(TEMPLATE){
     case 1:
         card_size.set(421, 595);
         card_amount = 4; 
-        textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/BACK.png'];
+        textures = getTextures(5);
         break;
     case 2:
         card_size.set(421, 421);
         card_amount = 9;
-        textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/6.png', 'pages/7.png', 
-        'pages/8.png', 'pages/9.png', 'pages/10.png', 'pages/11.png', 'pages/12.png', 'pages/13.png', 'pages/14.png', 'pages/15.png', 'pages/BACK.png'];
+        textures = getTextures(15);
         break;
     case 3:
         card_size.set(421, 595);
         card_amount = 8;
-        textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/6.png', 'pages/7.png', 
-        'pages/8.png', 'pages/9.png', 'pages/10.png', 'pages/11.png', 'pages/12.png', 'pages/13.png', 'pages/BACK.png'];
+        textures = getTextures(13);
         break;
     case 4:
         card_size.set(306, 396)
         card_amount = 8;
-        textures = ['pages/FRONT.png', 'pages/INNERFRONT.png', 'pages/1.png', 'pages/2.png', 'pages/3.png', 'pages/4.png', 'pages/5.png', 'pages/6.png', 'pages/7.png', 
-        'pages/8.png', 'pages/9.png', 'pages/10.png', 'pages/11.png', 'pages/12.png', 'pages/13.png', 'pages/BACK.png'];
+        textures = getTextures(13);
         break;
 }
 

--- a/ezmreader.js
+++ b/ezmreader.js
@@ -59,7 +59,7 @@ window.addEventListener('resize', function()
 
 // Preloader
 MANAGER.onLoad = function () {
-    LOADING_OVERLAY.classList.add('loading-hidden');
+    LOADING_OVERLAY.remove();
 }
 
 

--- a/ezmreader.js
+++ b/ezmreader.js
@@ -11,9 +11,8 @@
     
 */
 
-
 //---- USER OPTIONS ----//
-const TEMPLATE = 1;         // Change this value to set the template
+const TEMPLATE = 1; // Change this value to set the template
 /*  
     Available templates:
         1: 8 page folded zine or z-fold (default)
@@ -21,129 +20,96 @@ const TEMPLATE = 1;         // Change this value to set the template
         3: 16 page mini-booklet
         4: 16 page micro-mini
 */
-const BGCOLOR = 0xf5f5f5;   // Change this hex value to set the background color.
+const BGCOLOR = '#f5f5f5'; // Change this hex value to set the background color.
 //---- END USER OPTIONS ----//
-
 
 // Setup constants and variables
 const FOV = 45;
-const HEIGHT = 650;
-const VFOV = FOV * (Math.PI / 180);
-const MANAGER = new THREE.LoadingManager();
-const LOADER = new THREE.TextureLoader(MANAGER);
 const LOADING_OVERLAY = document.querySelector('#loading');
-let card_size = new THREE.Vector2();
 let card_amount;
 let current_state = 0;
 let textures = [];
-let cards = [];
-let texture_count = -1;
+let pages = [];
 
-
-// Three.js intitalization
-let renderer = new THREE.WebGLRenderer({antialias: true});
-renderer.setSize(window.innerWidth, window.innerHeight);
-renderer.setClearColor(BGCOLOR);
-document.body.appendChild(renderer.domElement);
-let scene = new THREE.Scene();
-let camera = new THREE.PerspectiveCamera(FOV, window.innerWidth/window.innerHeight, 1, 2000);
-camera.position.z = HEIGHT / (2* Math.tan(VFOV / 2) );
-camera.lookAt(scene.position);
-window.addEventListener('resize', function()
-{
-    renderer.setSize(window.innerWidth, window.innerHeight);
-    camera.aspect = window.innerWidth/window.innerHeight;
-    camera.updateProjectionMatrix();
-});
-
-
-// Preloader
-MANAGER.onLoad = function () {
-    LOADING_OVERLAY.remove();
-}
+document.body.style.background = BGCOLOR;
 
 function getTextures(num) {
-    return ['pages/FRONT.png', 'pages/INNERFRONT.png'].concat(new Array(num).fill().map((_, idx) => 'pages/' + (idx + 1) + '.png'), ['pages/BACK.png']);
+    return ['pages/FRONT.png', 'pages/INNERFRONT.png'].concat(
+        new Array(num).fill().map((_, idx) => 'pages/' + (idx + 1) + '.png'),
+        ['pages/BACK.png']
+    );
 }
 
 // Select template
-switch(TEMPLATE){
+switch (TEMPLATE) {
     default:
     case 1:
-        card_size.set(421, 595);
-        card_amount = 4; 
+        card_amount = 4;
         textures = getTextures(5);
         break;
     case 2:
-        card_size.set(421, 421);
         card_amount = 9;
         textures = getTextures(15);
         break;
     case 3:
-        card_size.set(421, 595);
-        card_amount = 8;
-        textures = getTextures(13);
-        break;
     case 4:
-        card_size.set(306, 396)
         card_amount = 8;
         textures = getTextures(13);
         break;
 }
 
+// Preloader
+Promise.all(
+    textures.map(
+        src =>
+            new Promise((resolve, reject) => {
+                const img = new Image();
+                img.onload = () => resolve(img);
+                img.onerror = reject;
+                img.src = src;
+                img.alt = src.split('/')[1].split('.')[0];
+            })
+    )
+)
+    .then(imgs => {
+        LOADING_OVERLAY.remove();
+        const list = document.createElement('ul');
+        pages = imgs.map((img, idx) => {
+            const li = document.createElement('li');
+            const flip = idx % 2;
+            li.className = 'depth-' + Math.min(2, idx);
+            li.style.transform = 'translateX(100%) rotateY(0deg) scaleZ(' + (flip ? -1 : 1) + ')';
+            li.appendChild(img);
+            list.appendChild(li);
+            return li;
+        });
+        document.body.appendChild(list);
 
-// Create cards
-for (let a=0; a < card_amount; a++){
+        function updatePerspective() {
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            list.style.perspective = Math.sqrt(((w / 2) * w) / 2 + ((h / 2) * h) / 2) / Math.tan(((FOV / 2) * Math.PI) / 180) + 'px';
+        }
 
-    let card_front_geo = new THREE.PlaneGeometry(card_size.x, card_size.y);
-    let card_back_geo = new THREE.PlaneGeometry(card_size.x, card_size.y);
-    card_back_geo.applyMatrix4(new THREE.Matrix4().makeRotationY(Math.PI));
-    texture_count += 1;
-    let card_front_tex = LOADER.load(textures[texture_count]);
-    card_front_tex.minFilter = THREE.LinearFilter;
-    texture_count += 1;
-    let card_back_tex = LOADER.load(textures[texture_count]);
-    card_back_tex.minFilter = THREE.LinearFilter;
-    let card_front_mat = new THREE.MeshBasicMaterial({map: card_front_tex});
-    let card_back_mat = new THREE.MeshBasicMaterial({map: card_back_tex});
-    card_front_mesh = new THREE.Mesh(card_front_geo, card_front_mat);
-    card_front_mesh.position.x = card_size.x / 2;
-    card_back_mesh = new THREE.Mesh(card_back_geo, card_back_mat);
-    card_back_mesh.position.x = card_size.x / 2;
-    let card = new THREE.Object3D();
-    
-    card.add(card_front_mesh);
-    card.add(card_back_mesh);
-    
-    if (a == 0){
-        card.position.z = 0;
-    } else if (a == 1){
-        card.position.z = -1;
-    } else {
-        card.position.z = -2;
-    }
-
-    cards.push(card);
-    scene.add(card);
-}
-
-function animate(){
-    requestAnimationFrame(animate);
-    renderer.render(scene, camera);
-}
-
+        window.addEventListener('resize', updatePerspective);
+        updatePerspective();
+    })
+    .catch(error => {
+        console.error(error);
+        LOADING_OVERLAY.textContent = 'Something went wrong! See console for details.';
+    });
 
 // Keyboard input
-document.addEventListener('keyup', function onKeyUp(key){
-    if (key.key === 'ArrowLeft' || key.key === 'a'){
+document.addEventListener('keyup', function onKeyUp(key) {
+    if (key.key === 'ArrowLeft' || key.key === 'a') {
         flipLeft();
-    } else if (key.key === 'ArrowRight' || key.key === 'd'){
+    } else if (key.key === 'ArrowRight' || key.key === 'd') {
         flipRight();
     }
 });
 
 // Mouse input
-document.addEventListener("pointerup", function onPointerUp(event){
+document.addEventListener('pointerup', function onPointerUp(event) {
     if (event.button !== 0) return;
     if (event.clientX < window.innerWidth / 2) {
         flipRight();
@@ -152,61 +118,38 @@ document.addEventListener("pointerup", function onPointerUp(event){
     }
 });
 
-// Flip page left
-function flipLeft(){
+function getPages(state) {
+    return [pages[state * 2], pages[state * 2 + 1]].filter(i => i);
+}
+function replaceTransformPerPage(state, search, replace) {
+    getPages(state).forEach(page => {
+        page.style.transform = page.style.transform.replace(search, replace);
+    });
+}
+function setDepth(state, depth) {
+    getPages(state).forEach(page => {
+        page.className = page.className.replace(/depth-\d+/, 'depth-' + Math.min(depth, 2));
+    });
+}
 
-    if (current_state < card_amount){
-        
-        gsap.to(cards[current_state].rotation, {duration: .8, y: -Math.PI, ease: "power2.inOut"});
-        
-        if (current_state > 0){
-            gsap.to(cards[current_state - 1].position, {duration: .3, z: -1});
-        }
-        
-        if (current_state > 1){
-            gsap.to(cards[current_state - 2].position, {duration: .3, z: -2});            
-        }
-        
-        if (current_state < card_amount - 1){
-            gsap.to(cards[current_state + 1].position, {duration: .3, z: 0});        
-        }
-        
-        if (current_state < card_amount - 2 ){
-            gsap.to(cards[current_state + 2].position, {duration: .3, z: -1});            
-        }
-        
-        current_state += 1;
-        
-    }
+// Flip page left
+function flipLeft() {
+    if (current_state >= card_amount) return;
+    replaceTransformPerPage(current_state, '0deg', '-180deg');
+    setDepth(current_state - 1, 1);
+    setDepth(current_state - 2, 2);
+    setDepth(current_state + 1, 0);
+    setDepth(current_state + 2, 1);
+    ++current_state;
 }
 
 // Flip page right
-function flipRight(){
-    
-     if (current_state > 0){
-
-        gsap.to(cards[current_state - 1].rotation, {duration: .8, y: 0, ease: "power2.inOut"});
-        
-        if (current_state > 2){
-            gsap.to(cards[current_state -3].position, {duration: .3, z: -1});
-        }
-
-        if (current_state > 1){
-            gsap.to(cards[current_state - 2].position, {duration: .3, z: 0});
-        }
-
-        if (current_state < card_amount - 1){
-            gsap.to(cards[current_state + 1].position, {duration: .3, z: -2});
-        }
-
-        if (current_state < card_amount){
-            gsap.to(cards[current_state].position, {duration: .3, z: -1});
-        }
-       
-        current_state -= 1;
-        
-    }
+function flipRight() {
+    if (current_state <= 0) return;
+    replaceTransformPerPage(current_state - 1, '-180deg', '0deg');
+    setDepth(current_state - 3, 1);
+    setDepth(current_state - 2, 0);
+    setDepth(current_state + 1, 2);
+    setDepth(current_state, 1);
+    --current_state;
 }
-
-// Animate, I guess.
-animate(); 

--- a/index.html
+++ b/index.html
@@ -1,21 +1,102 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <title>Reader for EZM</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r118/three.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.4.2/gsap.min.js"></script>
     <style>
-        * {padding: 0; margin: 0;}
-        canvas {display: block;  width: 100%; height: 100%; background-color: #f5f5f5;}
-        #loading {position: absolute; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; background-color: #f5f5f5; font-family: Sans-Serif;}
+        html,
+        body {
+            padding: 0;
+            margin: 0;
+            overflow: hidden;
+        }
+
+        #loading {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background-color: #f5f5f5;
+            font-family: Sans-Serif;
+        }
+
+        ul {
+            padding: 0;
+            margin: 0;
+            list-style: none;
+            position: absolute;
+            top: 0;
+            right: 0;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            transform-style: preserve-3d;
+            user-select: none;
+            perspective-origin: center;
+            perspective: 1000px;
+        }
+
+        li {
+            position: absolute;
+            top: 0;
+            right: 0;
+            left: 0;
+            bottom: 0;
+            width: 50%;
+            height: 100%;
+            backface-visibility: hidden;
+            transform-style: preserve-3d;
+            transform-origin: center left;
+            transition: transform 0.8s cubic-bezier(0.645, 0.045, 0.355, 1.000);
+        }
+
+        img {
+            position: absolute;
+            top: 0;
+            right: 0;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            backface-visibility: hidden;
+            object-fit: contain;
+            object-position: center left;
+            transition: transform 0.8s cubic-bezier(0.645, 0.045, 0.355, 1.000);
+        }
+        li:nth-child(even) img {
+            object-position: center right;
+        }
+
+        li.depth-0 img {
+            transform: translateZ(0) scaleX(1);
+        }
+        li:nth-child(even) img {
+            transform: translateZ(0) scaleX(-1);
+        }
+        li.depth-1 img {
+            transform: translateZ(-2px) scaleX(1);
+        }
+        li.depth-1:nth-child(even) img {
+            transform: translateZ(-2px) scaleX(-1);
+        }
+        li.depth-2 img {
+            transform: translateZ(-4px) scaleX(1);
+        }
+        li.depth-2:nth-child(even) img {
+            transform: translateZ(-4px) scaleX(-1);
+        }
     </style>
 </head>
+
 <body>
     <div id="loading">loading zine...</div>
     <script src="ezmreader.js"></script>
 
-<!--
+    <!--
 ▋ ▊ ▌ ▙ ▌ ▍ ▇ ▖ ▌ ▀ ▉ ▊ ▄ ▌ ▘ U E █ ▍ ▆ ▋ ▚ ▄ ▋ ▆ ▝ ▅ ▄ ▄ ▐ J D
 ▌ ▀ ▄ ▋ ▂ ▉ ▃ ▙ ▞ ▄ ▇ ▀ ▉ ▘ U Y U R ▋ ▚ ▛ ▀ ▄ ▎ ▍ ▋ ▖ ▋ ▂ O B ▄
 ▜ ▗ ▟ ▀ █ ▉ ▟ ▆ ▐ ▗ ▞ ▍ ▉ B J ▃ ▛ B R ▅ ▇ ▙ ▟ ▞ ▆ ▍ ▋ ▘ B B ▎ ▖
@@ -35,4 +116,5 @@ M O ▛ ▚ ▎ ▃ ▉ ▝ ▘ ▃ ▃ ▝ ▌ ▍ ▗ E O O D U Y O R M O O U 
 
 -->
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -2,19 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-
+    <title>Reader for EZM</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r118/three.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.4.2/gsap.min.js"></script>
-
-    <title>Reader for EZM</title>
+    <style>
+        * {padding: 0; margin: 0;}
+        canvas {display: block;  width: 100%; height: 100%; background-color: #f5f5f5;}
+        #loading {position: absolute; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; background-color: #f5f5f5; font-family: Sans-Serif;}
+    </style>
 </head>
 <body>
     <div id="loading">loading zine...</div>
-    <style>
-        * {padding: 0; margin: 0;} 
-        canvas {display: block;  width: 100%; height: 100%; background-color: #f5f5f5;} 
-        #loading {position: absolute; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; background-color: #f5f5f5; font-family: Sans-Serif;}
-    </style>
     <script src="ezmreader.js"></script>
 
 <!--

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
         * {padding: 0; margin: 0;} 
         canvas {display: block;  width: 100%; height: 100%; background-color: #f5f5f5;} 
         #loading {position: absolute; width: 100%; height: 100%; display: flex; justify-content: center; align-items: center; background-color: #f5f5f5; font-family: Sans-Serif;}
-        .loading-hidden {display: none !important}
     </style>
     <script src="ezmreader.js"></script>
 


### PR DESCRIPTION

- replaces raycast with basic input that checks whether the user clicked the left or right side of the screen
- replaces deprecated `keyCode` in key listener with `key`
- removes loading element from DOM when loaded instead of hiding it with CSS
- moves `style` tag to `head`
- reduces some duplicate code with switch fallthrough cases + helper functions
- replaces webgl renderer with DOM+CSS3
  - removes dependecy on threejs and greensock
  - removes need for update loop (all animation is handled via transitions instead of manually tweening values)
  - improves scaling (responsive vertically and horizontally)
  - removes need for specifying image size
  - adds basic load error handling
  - replaces integer background colour with css string

notes:
- in order to keep the list DOM semantic, there's no wrapper object for pairs of pages (`cards` in the original); instead, pairs of pages have their style updated simultaneously (`getPages` abstracts this a bit)
- the only user-facing change is that the background colour is now a CSS string instead of an integer
- the first few commits are all self-contained minor fixes/improvements, and then the last commit is the webgl -> css refactor
- because there's no differentiation between page sizes anymore, it would probably be possible to make `template` unnecessary with more work: instead of trying to load all the images for a specified template, images could be loaded incrementally in pairs until no more are found, using the loaded count to determine the number of pages