### PR TITLE
add various metadata to improve UX if hosted directly instead of embedded

### DIFF
--- a/ezmreader.js
+++ b/ezmreader.js
@@ -48,6 +48,10 @@ let textures = [];
 let pages = [];
 
 document.body.style.background = BGCOLOR;
+const metaTheme = document.createElement('meta');
+metaTheme.name = 'theme-color';
+metaTheme.content = BGCOLOR;
+document.head.appendChild(metaTheme);
 
 function getTextures(num) {
     return ['pages/FRONT.png', 'pages/INNERFRONT.png'].concat(

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:description" content="An electric zine" />
+    <meta property="og:image" content="./pages/FRONT.png" />
     <title>Reader for EZM</title>
     <style>
         html,

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:description" content="An electric zine" />
     <meta property="og:image" content="./pages/FRONT.png" />
+    <link rel="icon" href="./pages/FRONT.png" type="image/png" />
+    <link rel="apple-touch-icon" href="./pages/FRONT.png" type="image/png" />
     <title>Reader for EZM</title>
     <style>
         html,

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
 
     <meta name="description" content="An electric zine" />
     <meta property="og:description" content="An electric zine" />
-    <meta property="og:image" content="./pages/FRONT.png" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="./pages/FRONT.png" type="image/png" />

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Reader for EZM</title>
     <style>
         html,

--- a/index.html
+++ b/index.html
@@ -3,14 +3,16 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Reader for EZM</title>
     <meta property="og:title" content="Reader for EZM" />
+
     <meta name="description" content="An electric zine" />
     <meta property="og:description" content="An electric zine" />
     <meta property="og:image" content="./pages/FRONT.png" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="./pages/FRONT.png" type="image/png" />
     <link rel="apple-touch-icon" href="./pages/FRONT.png" type="image/png" />
-    <title>Reader for EZM</title>
     <style>
         html,
         body {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:title" content="Reader for EZM" />
     <meta name="description" content="An electric zine" />
     <meta property="og:description" content="An electric zine" />
     <meta property="og:image" content="./pages/FRONT.png" />

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="An electric zine" />
     <meta property="og:description" content="An electric zine" />
     <meta property="og:image" content="./pages/FRONT.png" />
     <link rel="icon" href="./pages/FRONT.png" type="image/png" />


### PR DESCRIPTION
- `og:title`, `description`, `og:description`: shows up in preview if linked on social media
- `viewport`: sets the initial scale and allows the user to pinch-zoom as needed
- `theme-color`: extends the background colour into the browser nav where applicable
- `icon`, `apple-touch-icon`: uses front cover as favicon/home screen icon