### PR TITLE
fix: show `noscript` warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
             padding: 0;
             margin: 0;
             overflow: hidden;
+            font-family: sans-serif;
+            text-align: center;
         }
 
         #loading {
@@ -20,7 +22,6 @@
             justify-content: center;
             align-items: center;
             background-color: #f5f5f5;
-            font-family: Sans-Serif;
         }
 
         ul {
@@ -93,6 +94,7 @@
 </head>
 
 <body>
+    <noscript>This electric zine requires javascript to be enabled.</noscript>
     <div id="loading">loading zine...</div>
     <script src="ezmreader.js"></script>
 </body>


### PR DESCRIPTION
the images are created + loaded through js, so the page is visually stuck on "loading zine..." when js is disabled; this shows a basic warning in that case for clarity